### PR TITLE
fixed getting interface lines

### DIFF
--- a/netctl
+++ b/netctl
@@ -94,7 +94,7 @@ get_ifs() {
 	# use co-process to preserve values set in while loop
 	ifconfig $1 |&
 	while IFS=' 	' read -r -p _l; do
-		[[ "${_l}" == *flags* ]] || continue
+		[[ "${_l}" == *:\ flags* ]] || continue
 
 		_if=${_l%%*([[:blank:]])*():*}
 


### PR DESCRIPTION
Hello,
Just fixed the  [bridge interface confuses netctl][1] issue. Since
The bridge's ifconfig output contains interface names and `flags`
keyword, adding the `: ` pattern seems to fix the problem.

Hope it helps

Before the changes:

```sh
$ netctl ls all
Locations:
        home
Configurations:
        home:
                hostname.re0
Interfaces:
        re0
        vether0 flags=3<LEARNING,DISCOVER>
        urtwn0
$ ifconfig bridge0
bridge0: flags=41<UP,RUNNING>
        description: switch1-uplink
        index 5 llprio 3
        groups: bridge
        priority 32768 hellotime 2 fwddelay 15 maxage 20 holdcnt 6 proto rstp
        vether0 flags=3<LEARNING,DISCOVER>
                port 6 ifpriority 0 ifcost 0
```

After the Changes:

```sh
$ netctl ls all
Locations:
        home
Configurations:
        home:
                hostname.re0
Interfa:
        re0
        urtwn0
```

[1]: https://github.com/akpoff/netctl/issues/3